### PR TITLE
Batch line count lookups for large diffs

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -20,7 +20,7 @@ import {
   getStagedFiles,
   getUnstagedFiles,
   getRecentCommits,
-  getFileLineCount,
+  getFileLineCounts,
   resolveBaseRef,
   resolveDiffArgs,
   resolveRef,
@@ -132,13 +132,17 @@ export function startServer(options: ServerOptions): Promise<ServerResult> {
   const includeUntracked = diffArgs.length === 0;
 
   function enrichWithLineCounts(diff: ParsedDiff, baseRef: string): ParsedDiff {
+    const paths = diff.files
+      .filter((f) => f.status !== 'added' && !f.isBinary)
+      .map((f) => f.oldPath || f.newPath)
+      .filter((path): path is string => Boolean(path));
+    const counts = getFileLineCounts(paths, baseRef);
     for (const file of diff.files) {
-      if (file.status === 'added' || file.isBinary) {
-        continue;
-      }
+      if (file.status === 'added' || file.isBinary) continue;
       const path = file.oldPath || file.newPath;
-      const count = getFileLineCount(path, baseRef);
-      if (count !== null) {
+      if (!path) continue;
+      const count = counts.get(path);
+      if (count !== undefined) {
         file.oldFileLineCount = count;
       }
     }
@@ -290,21 +294,16 @@ export function startServer(options: ServerOptions): Promise<ServerResult> {
           const baseRef = ref ? resolveBaseRef(ref) : 'HEAD';
 
           if (ref) {
-            sendJson(
-              res,
-              enrichWithLineCounts(
-                parseDiff(resolveRef(ref, extraArgs)),
-                baseRef,
-              ),
-            );
+            const raw = resolveRef(ref, extraArgs);
+            const parsed = parseDiff(raw);
+            sendJson(res, enrichWithLineCounts(parsed, baseRef));
             return;
           }
 
           const args = whitespace === 'hide' ? [...diffArgs, '-w'] : diffArgs;
-          sendJson(
-            res,
-            enrichWithLineCounts(parseDiff(getFullDiff(args)), baseRef),
-          );
+          const raw = getFullDiff(args);
+          const parsed = parseDiff(raw);
+          sendJson(res, enrichWithLineCounts(parsed, baseRef));
           return;
         }
 

--- a/packages/git/src/diff.ts
+++ b/packages/git/src/diff.ts
@@ -151,3 +151,31 @@ export function getFileLineCount(path: string, ref = 'HEAD'): number | null {
     return null;
   }
 }
+
+export function getFileLineCounts(paths: string[], ref = 'HEAD'): Map<string, number> {
+  if (paths.length === 0) return new Map();
+  const input = paths.map((p) => `${ref}:${p}`).join('\n') + '\n';
+  try {
+    const output = execWithStdin('git cat-file --batch', input);
+    const result = new Map<string, number>();
+    let pos = 0;
+    for (const path of paths) {
+      const headerEnd = output.indexOf('\n', pos);
+      if (headerEnd === -1) break;
+      const header = output.substring(pos, headerEnd);
+      const parts = header.split(' ');
+      if (parts[1] === 'missing') {
+        pos = headerEnd + 1;
+        continue;
+      }
+      const size = parseInt(parts[2], 10);
+      const contentStart = headerEnd + 1;
+      const content = output.substring(contentStart, contentStart + size);
+      result.set(path, content.split('\n').length);
+      pos = contentStart + size + 1; // skip trailing newline after content
+    }
+    return result;
+  } catch {
+    return new Map();
+  }
+}

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1,7 +1,7 @@
 export type { Commit, RepoInfo } from './types.js';
 export type { RefCapabilities } from './repo.js';
 export { isGitRepo, getRepoRoot, getRepoName, getCurrentBranch, getRepoInfo, getHeadHash, getDiffityDir, getDiffityDirPath, getRefCapabilities, isValidGitRef } from './repo.js';
-export { getDiff, getDiffFiles, getDiffStat, getDiffStatForRef, getUntrackedFiles, getUntrackedDiff, getFileContent, getFileLineCount, getMergeBase, normalizeRef, resolveBaseRef, resolveDiffArgs, resolveRef, revertFile, revertHunk, WORKING_TREE_REFS } from './diff.js';
+export { getDiff, getDiffFiles, getDiffStat, getDiffStatForRef, getUntrackedFiles, getUntrackedDiff, getFileContent, getFileLineCount, getFileLineCounts, getMergeBase, normalizeRef, resolveBaseRef, resolveDiffArgs, resolveRef, revertFile, revertHunk, WORKING_TREE_REFS } from './diff.js';
 export type { RefDiffArgs } from './diff.js';
 export { getStagedFiles, getUnstagedFiles, isDirty } from './status.js';
 export { getRecentCommits } from './commits.js';

--- a/packages/git/tests/get-diff-files.test.ts
+++ b/packages/git/tests/get-diff-files.test.ts
@@ -73,7 +73,7 @@ describe('getDiffFiles', () => {
     expect(files).toContain('staged-file.txt');
 
     git('reset HEAD staged-file.txt');
-    execSync(`rm "${join(repoDir, 'staged-file.txt')}"`, { stdio: 'pipe' });
+    rmSync(join(repoDir, 'staged-file.txt'), { force: true });
   });
 
   it('returns unstaged files for unstaged ref', async () => {
@@ -98,6 +98,6 @@ describe('getDiffFiles', () => {
 
     git('reset HEAD base.txt');
     git('checkout -- base.txt');
-    execSync(`rm "${join(repoDir, 'untracked-file.txt')}"`, { stdio: 'pipe' });
+    rmSync(join(repoDir, 'untracked-file.txt'), { force: true });
   });
 });

--- a/packages/git/tests/get-file-line-counts.test.ts
+++ b/packages/git/tests/get-file-line-counts.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let repoDir: string;
+let origCwd: string;
+
+function git(cmd: string) {
+  execSync(`git ${cmd}`, { cwd: repoDir, stdio: 'pipe' });
+}
+
+function writeFile(name: string, content: string) {
+  writeFileSync(join(repoDir, name), content);
+}
+
+beforeAll(() => {
+  origCwd = process.cwd();
+  repoDir = mkdtempSync(join(tmpdir(), 'diffity-test-'));
+
+  git('init -b main');
+  git('config user.email "test@test.com"');
+  git('config user.name "Test"');
+
+  writeFile('alpha.txt', 'alpha\nline');
+  writeFile('beta.txt', 'beta\nline\none');
+  git('add .');
+  git('commit -m "initial commit"');
+
+  process.chdir(repoDir);
+});
+
+afterAll(() => {
+  process.chdir(origCwd);
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe('getFileLineCounts', () => {
+  it('returns counts for multiple files in a single batch', async () => {
+    const { getFileLineCounts } = await import('../src/diff.js');
+    const counts = getFileLineCounts(['alpha.txt', 'missing.txt', 'beta.txt']);
+
+    expect(counts.get('alpha.txt')).toBe(2);
+    expect(counts.get('beta.txt')).toBe(3);
+    expect(counts.has('missing.txt')).toBe(false);
+    expect(counts.size).toBe(2);
+  });
+});


### PR DESCRIPTION
This batches file line-count retrieval for diff views so large change sets (1k+ files) no longer pay one `git show` call per file.

What changed:
- added `getFileLineCounts` in `@diffity/git` using a single `git cat-file --batch` call
- updated the CLI diff route to use the batched helper
- removed temporary debug/timing logs
- updated git package tests for the new batch path
- fixed Windows-safe cleanup in existing git tests

Validation:
- `npm run test -w @diffity/git`
- `npm run build -w diffity`
