### PR TITLE
Exclude untracked working-tree files from ref-range diffs

### DIFF
--- a/packages/git/src/diff.ts
+++ b/packages/git/src/diff.ts
@@ -38,7 +38,11 @@ export function resolveDiffArgs(ref: string): RefDiffArgs {
     case 'work':
       return { type: 'args', args: ['HEAD'], includeUntracked: true };
     default:
-      return { type: 'args', args: [normalizeRef(ref)], includeUntracked: true };
+      // Bare refs (`diffity main`) diff against the working tree, so untracked
+      // files are part of the change set (#10). Ranges (`A..B`) pin both
+      // endpoints — the working tree isn't involved, so untracked files must
+      // be excluded or the diff won't match `git diff A..B`.
+      return { type: 'args', args: [normalizeRef(ref)], includeUntracked: !ref.includes('..') };
   }
 }
 

--- a/packages/git/tests/get-diff-files.test.ts
+++ b/packages/git/tests/get-diff-files.test.ts
@@ -86,6 +86,28 @@ describe('getDiffFiles', () => {
     git('checkout -- base.txt');
   });
 
+  it('includes untracked files for bare refs (diff against working tree)', async () => {
+    const { getDiffFiles } = await import('../src/diff.js');
+    writeFile('untracked-file.txt', 'untracked\n');
+
+    const files = getDiffFiles('main');
+    expect(files).toContain('untracked-file.txt');
+
+    execSync(`rm "${join(repoDir, 'untracked-file.txt')}"`, { stdio: 'pipe' });
+  });
+
+  it('excludes untracked files for range refs (both endpoints pinned)', async () => {
+    const { getDiffFiles } = await import('../src/diff.js');
+    writeFile('untracked-file.txt', 'untracked\n');
+
+    const files = getDiffFiles('main..feature');
+    expect(files).toContain('feature.txt');
+    expect(files).toContain('base.txt');
+    expect(files).not.toContain('untracked-file.txt');
+
+    execSync(`rm "${join(repoDir, 'untracked-file.txt')}"`, { stdio: 'pipe' });
+  });
+
   it('returns working tree files for work ref', async () => {
     const { getDiffFiles } = await import('../src/diff.js');
     writeFile('untracked-file.txt', 'untracked\n');


### PR DESCRIPTION
## Summary

Since #11, explicit ref-range diffs (`diffity A..B`, `diffity A B`, `diffity --base A --compare B`) overlay untracked working-tree files onto the pinned commit-range diff, so the file list and insertion counts disagree with `git diff A..B` and GitHub's compare view.

#11 fixed #10 by flipping `includeUntracked` to `true` in the `default:` case of `resolveDiffArgs()`. That was right for bare refs (`diffity main`, `--base <sha>`), where the right side of the diff **is** the working tree — but the `default:` case is a catch-all that also covers `A..B` ranges, where both endpoints are pinned commits and the working tree isn't involved. `resolveRef()`, `getDiffFiles()`, and `getDiffStatForRef()` all inherit the flag.

## Change

- `resolveDiffArgs()`: gate `includeUntracked` on the ref not being a range (`!ref.includes('..')`). Bare refs keep the #10 behavior; ranges match `git diff A..B` again.
- Regression tests: range refs exclude untracked files; bare refs include them.

## Repro (before this fix)

Branch 1 commit ahead of main + 6 untracked files (295 lines):

| View | Files | Insertions | Deletions |
|---|---|---|---|
| `git diff --stat main..feature` | 54 | +4923 | −409 |
| `diffity main..feature` | 60 | +5218 | −409 |

Delta is exactly the untracked files (54+6, 4923+295).

## Testing

`vitest run` in `packages/git`: 7/7 pass; the new range test fails without the `diff.ts` change (verified red/green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)