### PR TITLE
fix(git): the file tree survives repositories larger than 1 MB of paths

### DIFF
--- a/packages/git/src/exec.ts
+++ b/packages/git/src/exec.ts
@@ -1,13 +1,24 @@
-import { execSync, type StdioOptions } from 'node:child_process';
+import {
+  execFileSync,
+  execSync,
+  type StdioOptions,
+} from 'node:child_process';
 
 const STDIO: StdioOptions = ['pipe', 'pipe', 'pipe'];
+
+/**
+ * Node's default is 1 MB, which is smaller than a large repository's file
+ * listing: `git ls-files` in a ~29k-file monorepo emits over 2 MB and the child
+ * process dies with ENOBUFS.
+ */
+const MAX_BUFFER = 50 * 1024 * 1024;
 
 export function execWithStdin(cmd: string, input: string): string {
   return execSync(cmd, {
     encoding: 'utf-8',
     stdio: STDIO,
     input,
-    maxBuffer: 50 * 1024 * 1024,
+    maxBuffer: MAX_BUFFER,
   });
 }
 
@@ -22,8 +33,21 @@ export function execLarge(cmd: string): string {
   return execSync(cmd, {
     encoding: 'utf-8',
     stdio: STDIO,
-    maxBuffer: 50 * 1024 * 1024,
+    maxBuffer: MAX_BUFFER,
   });
+}
+
+/**
+ * The argv form of `execLarge`, for commands whose arguments come from user
+ * input — a path with a space or a quote in it cannot be passed safely through
+ * a shell string.
+ */
+export function execFileLarge(command: string, args: string[]): string {
+  return execFileSync(command, args, {
+    encoding: 'utf-8',
+    stdio: STDIO,
+    maxBuffer: MAX_BUFFER,
+  }).trim();
 }
 
 export function execLines(cmd: string): string[] {

--- a/packages/git/src/tree.ts
+++ b/packages/git/src/tree.ts
@@ -1,6 +1,7 @@
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+import { execFileLarge } from './exec';
 
 export interface TreeEntry {
   type: 'blob' | 'tree';
@@ -11,19 +12,16 @@ export interface TreeEntry {
 function getWorkingTreeFiles(dirPath?: string): string[] {
   const pathArgs = dirPath ? [dirPath + '/'] : [];
 
-  const tracked = execFileSync('git', ['ls-files', ...pathArgs], {
-    encoding: 'utf-8',
-  }).trim();
+  const tracked = execFileLarge('git', ['ls-files', ...pathArgs]);
 
-  const deleted = execFileSync('git', ['ls-files', '--deleted', ...pathArgs], {
-    encoding: 'utf-8',
-  }).trim();
+  const deleted = execFileLarge('git', ['ls-files', '--deleted', ...pathArgs]);
 
-  const untracked = execFileSync(
-    'git',
-    ['ls-files', '--others', '--exclude-standard', ...pathArgs],
-    { encoding: 'utf-8' },
-  ).trim();
+  const untracked = execFileLarge('git', [
+    'ls-files',
+    '--others',
+    '--exclude-standard',
+    ...pathArgs,
+  ]);
 
   const deletedSet = new Set(deleted ? deleted.split('\n') : []);
   const files = new Set<string>();
@@ -71,30 +69,20 @@ export function getTreeEntries(_ref = 'HEAD', dirPath?: string): TreeEntry[] {
 }
 
 export function getTreeFingerprint(): string {
-  const tracked = execFileSync('git', ['ls-files'], {
-    encoding: 'utf-8',
-  }).trim();
+  const tracked = execFileLarge('git', ['ls-files']);
 
-  const statOutput = execFileSync(
-    'git',
-    ['status', '--porcelain', '-u'],
-    { encoding: 'utf-8' },
-  ).trim();
+  const statOutput = execFileLarge('git', ['status', '--porcelain', '-u']);
 
   return `${tracked.length}:${statOutput}`;
 }
 
 export function getWorkingTreeFileContent(filePath: string): string {
-  const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-    encoding: 'utf-8',
-  }).trim();
+  const root = execFileLarge('git', ['rev-parse', '--show-toplevel']);
   return readFileSync(join(root, filePath), 'utf-8');
 }
 
 export function getWorkingTreeRawFile(filePath: string): { data: Buffer; fullPath: string } {
-  const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-    encoding: 'utf-8',
-  }).trim();
+  const root = execFileLarge('git', ['rev-parse', '--show-toplevel']);
   const fullPath = join(root, filePath);
   return { data: readFileSync(fullPath), fullPath };
 }

--- a/packages/git/tests/get-tree-large-repo.test.ts
+++ b/packages/git/tests/get-tree-large-repo.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { getTree, getTreeFingerprint } from '../src/tree';
+
+/**
+ * Node's default maxBuffer is 1 MB. A repository whose file listing is larger
+ * than that used to kill `git ls-files` with ENOBUFS, which surfaced as
+ * "Failed to get tree" for every large repo.
+ */
+const DEFAULT_MAX_BUFFER = 1024 * 1024;
+
+let repoDir: string;
+let origCwd: string;
+
+function git(cmd: string) {
+  // This fixture is deliberately larger than the default 1 MB buffer, and
+  // `git commit` names every file it creates — so the setup needs the same
+  // headroom the code under test does.
+  execSync(`git ${cmd}`, {
+    cwd: repoDir,
+    stdio: 'pipe',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+}
+
+beforeAll(() => {
+  origCwd = process.cwd();
+  repoDir = mkdtempSync(join(tmpdir(), 'diffity-large-tree-'));
+
+  git('init -b main');
+  git('config user.email "test@test.com"');
+  git('config user.name "Test"');
+
+  // Enough path bytes to exceed the default buffer: names are padded so the
+  // listing crosses 1 MB without needing tens of thousands of files.
+  const padding = 'p'.repeat(180);
+  mkdirSync(join(repoDir, 'many'));
+  for (let i = 0; i < 6000; i += 1) {
+    writeFileSync(join(repoDir, 'many', `f${i}-${padding}.txt`), '');
+  }
+  git('add .');
+  git('commit -m "many files"');
+
+  process.chdir(repoDir);
+});
+
+afterAll(() => {
+  process.chdir(origCwd);
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe('a repository whose listing exceeds the default buffer', () => {
+  it('lists every file rather than throwing ENOBUFS', () => {
+    const paths = getTree();
+
+    expect(paths).toHaveLength(6000);
+    expect(paths.join('\n').length).toBeGreaterThan(DEFAULT_MAX_BUFFER);
+  });
+
+  it('still fingerprints the tree', () => {
+    expect(getTreeFingerprint()).toMatch(/^\d+:/);
+  });
+});


### PR DESCRIPTION
Addresses #24 (deliberately not `Closes`, see the last section).

## What happens

On a large repository, the file tree fails to load and the UI shows:

```
Failed to get tree: Error: spawnSync git ENOBUFS
```

Reproduced on a monorepo with ~29,000 tracked files, where `git ls-files` emits 2.3 MB. `/api/tree` and `/api/tree/fingerprint` both return 500, so the file browser is unusable and so is any tour, since the tour view reads the tree.

## Why

`getWorkingTreeFiles` and `getTreeFingerprint` in `packages/git/src/tree.ts` call `execFileSync` without a `maxBuffer`, so they inherit Node's 1 MB default. Any repository whose listing exceeds that kills the child process before it can return.

`packages/git/src/exec.ts` already had the 50 MB ceiling these calls needed — but only on its string-command helpers (`execLarge`, `execWithStdin`), and `tree.ts` never used them.

## The fix

`tree.ts` passes argv arrays rather than shell strings, and it should keep doing that: a repository path can contain a space or a quote, and building a shell string out of `dirPath` would break on both. So rather than converting these calls to `execLarge`, this adds the argv form of it:

- `execFileLarge(command, args)` in `exec.ts`, alongside the existing helpers
- the repeated `50 * 1024 * 1024` becomes a named `MAX_BUFFER`, with a comment saying what overruns the default
- all seven `execFileSync` calls in `tree.ts` route through the new helper

Net effect is that the whole class of failure is gone from that file, not just the one call that happened to be hit first.

## Testing

`packages/git/tests/get-tree-large-repo.test.ts` builds a temp repository whose listing crosses 1 MB and asserts `getTree()` returns every file. It follows the fixture style of `get-diff-files.test.ts`.

- Without the fix, both cases fail with `Error: spawnSync git ENOBUFS` — the exact error from the report.
- With the fix, `@diffity/git` is 7/7 and the full suite is 75/75 across the three packages. `tsc` is clean.

One note on the test: the fixture is deliberately over the limit, and `git commit` names every file it creates, so the setup helper needs the same headroom as the code under test. Without that it fails in `beforeAll` for its own reasons rather than testing anything.

## What this does not fix

#24 reports two things, and this PR only fixes one of them. The reporter also notes that the failure takes down views that do not need the file tree at all:

> Since the SPA surfaces that at the top level, views that don't even need the file tree (a code tour) go down with it too.

That is a separate defect — a `/api/tree` 500 should degrade the file browser, not replace the whole app with an error page. A tour has its own data and can render without the tree. This PR does not touch the error boundary, so the issue should stay open for that half if you agree it is worth fixing; hence no closing keyword above.

## Also worth a look

`packages/github/src/pr.ts` uses a 10 MB buffer for `gh api ... --paginate` on PR comments. That is far more headroom than this was, so it is likely fine, but it is the same pattern of a per-call literal rather than the shared constant.
